### PR TITLE
potentially fix SID_output.neur_rad when optimize_kernel=False and us…

### DIFF
--- a/sid_main.m
+++ b/sid_main.m
@@ -263,6 +263,9 @@ if Input.optimize_kernel
     end
     opts.ker_shape = 'user';
     opts.ker_param = kernel;
+else
+    % no kernel optimization
+    SID_output.neur_rad = Input.neur_rad;
 end
 
 SID_output.recon = reconstruct_S(SID_output.S, psf_ballistic, opts);


### PR DESCRIPTION
…e_std_GLL=True (or GPU)

@hossein192003 ran into an issue in `sid_main.m` with "Strategy 1" when `Input.optimize_kernel=False` but `Input.use_std_GLL=True`. `SID_output.neur_rad` is never set but called in [line 407](https://github.com/vazirilab/SID/blob/67c3d35bc04ca2cc37ff29ad16258dc8bcda2f11/sid_main.m#L407). 

Might be worth overall checking on this parameter, as it is set multiple times in either `Input`, `SID_output`, and `opts`. There is e.g. a [hard-coded](https://github.com/vazirilab/SID/blob/67c3d35bc04ca2cc37ff29ad16258dc8bcda2f11/sid_main.m#L312) value `opts.neur_rad = 6`.